### PR TITLE
Fix CXX path for host

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 523d60a98af0c07e972338f3a5f07d7ea1232d6e67b0f063e139d986f09b9864
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py>30]
   merge_build_host: True
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   skip: True  # [win or py>30]
+  merge_build_host: True
 
 requirements:
   build:
@@ -49,6 +50,7 @@ requirements:
     - python
     - scipy
     - zlib
+    - {{ compiler('cxx') }}
 
 test:
   imports:


### PR DESCRIPTION
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

We make sure that the CXX path detected by CMake is available at runtime by merging
the build and host environment and adding `{{ compiler('cxx') }}` as a runtime dependency.