### PR TITLE
Set build string so dependees can choose mpi version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set version = "2.2.2" %}
 
+{% set mpi_prefix = "mpi_" + mpi %}
+
 package:
   name: triqs
   version: {{ version }}
@@ -9,7 +11,7 @@ source:
   sha256: b7fc1f22aca3dc8f353c3aee416c20d1d4991d42b008b257d0290690da39d5ad
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win or py>30]
   merge_build_host: True
 
@@ -23,8 +25,10 @@ requirements:
   host:
     - boost-cpp
     - fftw
+    - fftw * {{ mpi_prefix }}_*
     - gmp
     - hdf5
+    - hdf5 * {{ mpi_prefix }}_*
     - h5py
     - mako
     - mpi4py
@@ -38,8 +42,10 @@ requirements:
     - zlib
   run:
     - fftw
+    - fftw * {{ mpi_prefix }}_*
     - gmp
     - hdf5
+    - hdf5 * {{ mpi_prefix }}_*
     - h5py
     - mako
     - mpi4py
@@ -58,7 +64,7 @@ test:
 
 about:
   home: https://triqs.github.io
-  license: GPLv3
+  license: GPL-3.0-or-later
   license_family: GPL
   license_file: LICENSE.txt
   summary: 'Toolbox for Research on Interacting Quantum Systems'


### PR DESCRIPTION
-Specify mpi version also for fftw / hdf5

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
