### PR TITLE
Remove empty build requirements to avoid conda smithy bug in osx arm migration

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,11 @@ source:
   sha256: cf4f6064ea962fc088e0c2833bf7c4e52f4c827ea331bf3c57d1c9303649042b
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win or py<30]
   merge_build_host: true
 
 requirements:
-  build: []
   host:
     - cmake
     - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,17 +13,16 @@ source:
 build:
   number: 4
   skip: true  # [win or py<30]
-  merge_build_host: true
 
 requirements:
-  host:
-    - cmake
+  build:
     - make
-    - clangxx  # [osx]
+    - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - clangxx  # [osx]
+  host:
     - boost-cpp
-
     - fftw
     - fftw * {{ mpi_prefix }}_*
     - gmp


### PR DESCRIPTION
C.f. title

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
