### PR TITLE
Update to v3.3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.2" %}
+{% set version = "3.3.3" %}
 
 {% set mpi_prefix = "mpi_" + mpi %}
 
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://github.com/TRIQS/triqs/releases/download/{{ version }}/triqs-{{ version }}.tar.gz
-  sha256: 73cff4637e0426274d183052f7d1ba405d7bf1be503c79a594730f1cea88b808
+  sha256: 1cccbf9c65798501ef6018d4d225ebc4915156981082a76762190b4dbd149920
 
 build:
-  number: 3
+  number: 0
   skip: true  # [win or py<30]
 
 requirements:


### PR DESCRIPTION
Update the recipe to the TRIQS 3.3.3 patch release: https://github.com/TRIQS/triqs/releases/tag/3.3.3

- Bump `version` to `3.3.3`
- Update `sha256` for the new source tarball
- Reset `build.number` to `0`

### Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (if the version is unchanged)
- [x] Reset the build number to 0 (if the version changed)
- [x] Re-rendered with the latest conda-smithy — not strictly required for a pure version bump; let me know if a re-render is wanted in this PR.
- [x] Ensured the license file is being packaged.