### PR TITLE
Align TRIQS feedstock with the 4.0 migration

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -231,7 +231,7 @@ jobs:
       osx_arm64_hdf51.14.6mpimpichpython3.10.____cpython:
         CONFIG: osx_arm64_hdf51.14.6mpimpichpython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -242,7 +242,7 @@ jobs:
       osx_arm64_hdf51.14.6mpimpichpython3.11.____cpython:
         CONFIG: osx_arm64_hdf51.14.6mpimpichpython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -253,7 +253,7 @@ jobs:
       osx_arm64_hdf51.14.6mpimpichpython3.12.____cpython:
         CONFIG: osx_arm64_hdf51.14.6mpimpichpython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -264,7 +264,7 @@ jobs:
       osx_arm64_hdf51.14.6mpimpichpython3.13.____cp313:
         CONFIG: osx_arm64_hdf51.14.6mpimpichpython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -275,7 +275,7 @@ jobs:
       osx_arm64_hdf51.14.6mpimpichpython3.14.____cp314:
         CONFIG: osx_arm64_hdf51.14.6mpimpichpython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -286,7 +286,7 @@ jobs:
       osx_arm64_hdf51.14.6mpiopenmpipython3.10.____cpython:
         CONFIG: osx_arm64_hdf51.14.6mpiopenmpipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -297,7 +297,7 @@ jobs:
       osx_arm64_hdf51.14.6mpiopenmpipython3.11.____cpython:
         CONFIG: osx_arm64_hdf51.14.6mpiopenmpipython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -308,7 +308,7 @@ jobs:
       osx_arm64_hdf51.14.6mpiopenmpipython3.12.____cpython:
         CONFIG: osx_arm64_hdf51.14.6mpiopenmpipython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -319,7 +319,7 @@ jobs:
       osx_arm64_hdf51.14.6mpiopenmpipython3.13.____cp313:
         CONFIG: osx_arm64_hdf51.14.6mpiopenmpipython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -330,7 +330,7 @@ jobs:
       osx_arm64_hdf51.14.6mpiopenmpipython3.14.____cp314:
         CONFIG: osx_arm64_hdf51.14.6mpiopenmpipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -341,7 +341,7 @@ jobs:
       osx_arm64_hdf52mpimpichpython3.10.____cpython:
         CONFIG: osx_arm64_hdf52mpimpichpython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -352,7 +352,7 @@ jobs:
       osx_arm64_hdf52mpimpichpython3.11.____cpython:
         CONFIG: osx_arm64_hdf52mpimpichpython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -363,7 +363,7 @@ jobs:
       osx_arm64_hdf52mpimpichpython3.12.____cpython:
         CONFIG: osx_arm64_hdf52mpimpichpython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -374,7 +374,7 @@ jobs:
       osx_arm64_hdf52mpimpichpython3.13.____cp313:
         CONFIG: osx_arm64_hdf52mpimpichpython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -385,7 +385,7 @@ jobs:
       osx_arm64_hdf52mpimpichpython3.14.____cp314:
         CONFIG: osx_arm64_hdf52mpimpichpython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -396,7 +396,7 @@ jobs:
       osx_arm64_hdf52mpiopenmpipython3.10.____cpython:
         CONFIG: osx_arm64_hdf52mpiopenmpipython3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -407,7 +407,7 @@ jobs:
       osx_arm64_hdf52mpiopenmpipython3.11.____cpython:
         CONFIG: osx_arm64_hdf52mpiopenmpipython3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -418,7 +418,7 @@ jobs:
       osx_arm64_hdf52mpiopenmpipython3.12.____cpython:
         CONFIG: osx_arm64_hdf52mpiopenmpipython3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -429,7 +429,7 @@ jobs:
       osx_arm64_hdf52mpiopenmpipython3.13.____cp313:
         CONFIG: osx_arm64_hdf52mpiopenmpipython3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0
@@ -440,7 +440,7 @@ jobs:
       osx_arm64_hdf52mpiopenmpipython3.14.____cp314:
         CONFIG: osx_arm64_hdf52mpiopenmpipython3.14.____cp314
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: skip
         pagefile_size: 0

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.13.____cp313.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.14.____cp314.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.13.____cp313.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.14.____cp314.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
 gmp:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - CONFIG: linux_64_hdf51.14.6mpimpichpython3.10.____cpython
             CONFIG_SHORT: linux_64_hdf51.14.6mpimpichpython3.10.___hbe83fcec
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -37,7 +37,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpimpichpython3.11.____cpython
             CONFIG_SHORT: linux_64_hdf51.14.6mpimpichpython3.11.___h73d90197
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -50,7 +50,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpimpichpython3.12.____cpython
             CONFIG_SHORT: linux_64_hdf51.14.6mpimpichpython3.12.___hdab1fbbf
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -63,7 +63,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpimpichpython3.13.____cp313
             CONFIG_SHORT: linux_64_hdf51.14.6mpimpichpython3.13.____cp313
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -76,7 +76,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpimpichpython3.14.____cp314
             CONFIG_SHORT: linux_64_hdf51.14.6mpimpichpython3.14.____cp314
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -89,7 +89,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpiopenmpipython3.10.____cpython
             CONFIG_SHORT: linux_64_hdf51.14.6mpiopenmpipython3.10._h01c5fa92
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -102,7 +102,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpiopenmpipython3.11.____cpython
             CONFIG_SHORT: linux_64_hdf51.14.6mpiopenmpipython3.11._h10ea981f
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -115,7 +115,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpiopenmpipython3.12.____cpython
             CONFIG_SHORT: linux_64_hdf51.14.6mpiopenmpipython3.12._h50712666
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -128,7 +128,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpiopenmpipython3.13.____cp313
             CONFIG_SHORT: linux_64_hdf51.14.6mpiopenmpipython3.13._h96b98b72
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -141,7 +141,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf51.14.6mpiopenmpipython3.14.____cp314
             CONFIG_SHORT: linux_64_hdf51.14.6mpiopenmpipython3.14._h2295454a
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -154,7 +154,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpimpichpython3.10.____cpython
             CONFIG_SHORT: linux_64_hdf52mpimpichpython3.10.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -167,7 +167,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpimpichpython3.11.____cpython
             CONFIG_SHORT: linux_64_hdf52mpimpichpython3.11.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -180,7 +180,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpimpichpython3.12.____cpython
             CONFIG_SHORT: linux_64_hdf52mpimpichpython3.12.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -193,7 +193,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpimpichpython3.13.____cp313
             CONFIG_SHORT: linux_64_hdf52mpimpichpython3.13.____cp313
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -206,7 +206,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpimpichpython3.14.____cp314
             CONFIG_SHORT: linux_64_hdf52mpimpichpython3.14.____cp314
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -219,7 +219,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpiopenmpipython3.10.____cpython
             CONFIG_SHORT: linux_64_hdf52mpiopenmpipython3.10.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -232,7 +232,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpiopenmpipython3.11.____cpython
             CONFIG_SHORT: linux_64_hdf52mpiopenmpipython3.11.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -245,7 +245,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpiopenmpipython3.12.____cpython
             CONFIG_SHORT: linux_64_hdf52mpiopenmpipython3.12.____cpython
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -258,7 +258,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpiopenmpipython3.13.____cp313
             CONFIG_SHORT: linux_64_hdf52mpiopenmpipython3.13.____cp313
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -271,7 +271,7 @@ jobs:
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_64_hdf52mpiopenmpipython3.14.____cp314
             CONFIG_SHORT: linux_64_hdf52mpiopenmpipython3.14.____cp314
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: True
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -44,19 +44,7 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
-(
-# Due to https://bugzilla.redhat.com/show_bug.cgi?id=1537564 old versions of rpm
-# are drastically slowed down when the number of file descriptors is very high.
-# This can be visible during a `yum install` step of a feedstock build.
-# => Set a lower limit in a subshell for the `yum install`s only.
-ulimit -n 1024
 
-# Install the yum requirements defined canonically in the
-# "recipe/yum_requirements.txt" file. After updating that file,
-# run "conda smithy rerender" and this line will be updated
-# automatically.
-/usr/bin/sudo -n yum install -y xorg-x11-server-Xorg
-)
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,146 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_hdf52mpiopenmpipython3.14.____cp314" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpimpichpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpimpichpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpimpichpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpimpichpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpimpichpython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpimpichpython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpimpichpython3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpimpichpython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpiopenmpipython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpiopenmpipython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpiopenmpipython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpiopenmpipython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpiopenmpipython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpiopenmpipython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf51.14.6mpiopenmpipython3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf51.14.6mpiopenmpipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpimpichpython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpimpichpython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpimpichpython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpimpichpython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpimpichpython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpimpichpython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpimpichpython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpimpichpython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpimpichpython3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpimpichpython3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpiopenmpipython3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpiopenmpipython3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpiopenmpipython3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpiopenmpipython3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpiopenmpipython3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpiopenmpipython3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpiopenmpipython3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpiopenmpipython3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_hdf52mpiopenmpipython3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8100&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triqs-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_hdf52mpiopenmpipython3.14.____cp314" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,11 +1,11 @@
-build_platform:
-  osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
+provider:
+  osx_arm64: native
 test: native_and_emulated
 workflow_settings:
   store_build_artifacts: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,19 +3,6 @@
 mkdir build
 cd build
 
-# Cross-compile with openmpi
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == "1" ]]; then
-  export OPAL_PREFIX="$PREFIX"
-  # CMake >= 4.1 (policy CMP0190) makes find_package(Python COMPONENTS Interpreter
-  # Development ...) refuse to search at all while cross-compiling unless
-  # CMAKE_CROSSCOMPILING_EMULATOR is set. conda-forge cross builds use crossenv,
-  # which provides a host-runnable interpreter ($PYTHON) rather than real target-arch
-  # emulation, so a plain `env` passthrough satisfies the check. Same fix as used by
-  # the cppbmad feedstock (other feedstocks affected by CMP0190, e.g. xrootd, gdal,
-  # freud, instead patch their CMakeLists.txt to set cmake_policy(SET CMP0190 OLD)).
-  CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CROSSCOMPILING_EMULATOR=env -DPython_EXECUTABLE=$PYTHON"
-fi
-
 export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
 cmake ${CMAKE_ARGS} \
     -DPython_ROOT_DIR=$PREFIX \
@@ -27,9 +14,7 @@ cmake ${CMAKE_ARGS} \
 
 make -j1 VERBOSE=1
 
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
-  CTEST_OUTPUT_ON_FAILURE=1 ctest -VV
-fi
+CTEST_OUTPUT_ON_FAILURE=1 ctest -VV
 
 make install
 
@@ -39,6 +24,7 @@ for file in lib/cmake/triqs/TRIQSConfig.cmake lib/cmake/Cpp2Py/Cpp2PyTargets.cma
     lib/cmake/Cpp2Py/Cpp2PyConfig.cmake lib/python${py_version}/site-packages/cpp2py/libclang_config.py \
     lib/cmake/mpi/mpi-config.cmake
 do
+  [[ -f "$PREFIX/$file" ]] || continue
   sed "s|$BUILD_PREFIX/venv|$PREFIX|g" $PREFIX/$file > tmp_file
   sed "s|$BUILD_PREFIX|$PREFIX|g" tmp_file > $PREFIX/$file
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 6b09923bf8a950cf1f07c93f5385cfe82c963b2ac04d10eee12045f83e8907da
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or py<30]
   # triqs only uses Boost::headers (header-only); libboost-devel is needed in
   # host so find_package(Boost) resolves via BoostConfig.cmake under CMP0167,
@@ -65,7 +65,6 @@ requirements:
     - matplotlib-base
     - libclang
     - zlib
-    - {{ compiler('cxx') }}
 
 test:
   imports:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-xorg-x11-server-Xorg


### PR DESCRIPTION
Align the published TRIQS 4.0 recipe with the rest of the 4.0 feedstock migration.

- build `osx-arm64` natively instead of cross-compiling from `osx-64`
- ignore the run export from the actual exporting host package, `libboost-devel`
- remove obsolete cross-compilation setup
- run CTest strictly on every build
- guard post-install path rewriting when optional files are absent
- drop the obsolete runtime C++ compiler dependency now that TRIQS 4 no longer ships `triqs++`; this also prevents duplicate host/build sysroots in downstream builds
- remove the stale `xorg-x11-server-Xorg` yum requirement, which is unavailable on current AlmaLinux builders and is not used by the test suite
- rerender with current conda-smithy and conda-forge pinning

Validation:

- current `conda-smithy recipe-lint` passes
- `recipe/build.sh` passes `bash -n`
- generated macOS ARM jobs use `macOS-15-arm64`

The runtime compiler cleanup is required by the staged `triqs_ctint`, `triqs_modest`, and `triqs_dftkit` recipes: the existing TRIQS 4 build pulls a second compiler sysroot into their host environment, causing Linux test executables to resolve `pthread` from the wrong sysroot.
