### PR TITLE
triqs v4.0.1

### DIFF
--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.10.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.11.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.12.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.13.____cp313.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf52mpimpichpython3.14.____cp314.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.10.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.11.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.12.____cpython.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.13.____cp313.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/linux_64_hdf52mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/linux_64_hdf52mpiopenmpipython3.14.____cp314.yaml
@@ -18,6 +18,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/osx_64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_hdf52mpimpichpython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_hdf52mpimpichpython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_hdf52mpimpichpython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/osx_64_hdf52mpimpichpython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/osx_64_hdf52mpimpichpython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_64_hdf52mpiopenmpipython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/osx_64_hdf52mpiopenmpipython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/osx_64_hdf52mpiopenmpipython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/osx_64_hdf52mpiopenmpipython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_64_hdf52mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/osx_64_hdf52mpiopenmpipython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpimpichpython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6mpiopenmpipython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpimpichpython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf52mpimpichpython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpimpichpython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf52mpimpichpython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpimpichpython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf52mpimpichpython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpimpichpython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_hdf52mpimpichpython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpimpichpython3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_hdf52mpimpichpython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpiopenmpipython3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf52mpiopenmpipython3.10.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpiopenmpipython3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf52mpiopenmpipython3.11.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpiopenmpipython3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_hdf52mpiopenmpipython3.12.____cpython.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpiopenmpipython3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_hdf52mpiopenmpipython3.13.____cp313.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/.ci_support/osx_arm64_hdf52mpiopenmpipython3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_hdf52mpiopenmpipython3.14.____cp314.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fftw:
 - '3'
+fmt:
+- '12.1'
 gmp:
 - '6'
 hdf5:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@ cd build
 
 export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
 cmake ${CMAKE_ARGS} \
+    -DBuild_Deps=IfNotFound \
     -DPython_ROOT_DIR=$PREFIX \
     -DLIBCLANG_LOCATION=$PREFIX/lib \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0" %}
+{% set version = "4.0.1" %}
 
 {% set mpi_prefix = "mpi_" + mpi %}
 
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://github.com/TRIQS/triqs/releases/download/{{ version }}/triqs-{{ version }}.tar.gz
-  sha256: 6b09923bf8a950cf1f07c93f5385cfe82c963b2ac04d10eee12045f83e8907da
+  sha256: e27ea2c09e6eb22a580b85e3d6f6c3f93c985e9c633646f1a265ef81612c2b9e
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win or py<30]
   # triqs only uses Boost::headers (header-only); libboost-devel is needed in
   # host so find_package(Boost) resolves via BoostConfig.cmake under CMP0167,
@@ -36,6 +36,7 @@ requirements:
     - libboost-devel
     - fftw
     - fftw * {{ mpi_prefix }}_*
+    - fmt
     - gmp
     - hdf5
     - hdf5 * {{ mpi_prefix }}_*


### PR DESCRIPTION
Bumps TRIQS to [4.0.1](https://github.com/TRIQS/triqs/releases/tag/4.0.1), a patch release with minor fixes and improvements ([ChangeLog](https://github.com/TRIQS/triqs/blob/4.0.x/doc/ChangeLog.md)).

This PR also switches the build to the conda-forge `fmt` package instead of the copy TRIQS vendors as a cmake sub-project: `fmt` is added to `host:`, and `-DBuild_Deps=IfNotFound` is passed in `build.sh`.

The two changes ship together deliberately. Consuming an external fmt requires TRIQS >= 4.0.1: the installed `TRIQSConfig.cmake` only learned to resolve fmt via `find_dep(fmt)` in 4.0.1 (TRIQS/triqs@8bd6fa3), before which it hard-coded an include of the bundled fmt's targets file via `FMT_CMAKE_DIR`, which is only set when fmt is built as a sub-project. The equivalent fix is present in cppdlr `1.3.x` (flatironinstitute/cppdlr@0214de6), which is built from source as part of this build.

`fmt` is host-only — the run dependency comes from fmt's `run_exports`.

A re-render is needed so the `fmt` pin lands in `.ci_support/`, since `fmt` is newly added to `host:`.

Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [ ] Bumped the build number (if the version is unchanged)
- [x] Reset the build number to 0 (if the version changed)
- [ ] Re-rendered with the latest conda-smithy (Use the phrase `@conda-forge-admin, please rerender` in a comment in this PR for automated rerendering)
- [x] Ensured the license file is being packaged.
